### PR TITLE
Fancy Scene transitions

### DIFF
--- a/Assets/Scenes/Main Menu.unity
+++ b/Assets/Scenes/Main Menu.unity
@@ -215,7 +215,7 @@ MonoBehaviour:
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
+          m_IntArgument: 1
           m_FloatArgument: 0
           m_StringArgument: 
           m_BoolArgument: 0
@@ -638,7 +638,7 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: 1830021531}
         m_TargetAssemblyTypeName: PauseManager, Assembly-CSharp
         m_MethodName: Volume
         m_Mode: 0
@@ -5308,9 +5308,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 21d455e395466b84c92bd0f8034b778a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  pauseCanvas: {fileID: 0}
-  volumeSlider: {fileID: 0}
-  volumeNumText: {fileID: 0}
+  pauseCanvas: {fileID: 342095882}
+  volumeSlider: {fileID: 181020082}
+  volumeNumText: {fileID: 1319939814}
   pauseAction: {fileID: 1918995285568225065, guid: 6b406d379bacdd7409b013fcd8f2a0a1, type: 3}
 --- !u!4 &1830021532
 Transform:
@@ -6156,6 +6156,197 @@ RectTransform:
   m_AnchoredPosition: {x: -5, y: 0}
   m_SizeDelta: {x: -20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &199061206498092426
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6235660659267419138}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1019030657948720838
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4192827954099044546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c25d4aa611322dd44b300305eaab1d00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  image: {fileID: 199061206498092426}
+--- !u!1 &4192827954099044546
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6547613837216732147}
+  - component: {fileID: 5349078780633977642}
+  - component: {fileID: 6194183969060900790}
+  - component: {fileID: 7541924917667814284}
+  - component: {fileID: 1019030657948720838}
+  m_Layer: 5
+  m_Name: Scene Transition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 2147483647
+  m_IsActive: 1
+--- !u!222 &5197309595740819216
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6235660659267419138}
+  m_CullTransparentMesh: 1
+--- !u!223 &5349078780633977642
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4192827954099044546}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &6194183969060900790
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4192827954099044546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!1 &6235660659267419138
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6424134548089085737}
+  - component: {fileID: 5197309595740819216}
+  - component: {fileID: 199061206498092426}
+  m_Layer: 5
+  m_Name: Fade
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 2147483647
+  m_IsActive: 1
+--- !u!224 &6424134548089085737
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6235660659267419138}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 40, y: 40, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6547613837216732147}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!224 &6547613837216732147
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4192827954099044546}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6424134548089085737}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &7541924917667814284
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4192827954099044546}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 0
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -6165,3 +6356,4 @@ SceneRoots:
   - {fileID: 1010334588}
   - {fileID: 1910121510}
   - {fileID: 238877662}
+  - {fileID: 6547613837216732147}

--- a/Assets/Scripts/Managment/PauseManager.cs
+++ b/Assets/Scripts/Managment/PauseManager.cs
@@ -20,29 +20,42 @@ public class PauseManager : MonoBehaviour
 
     void Awake()
     {
-        pauseAction.action.performed += Pause;
-        pauseAction.action.Enable();
+        if (pauseAction != null)
+        {
+            pauseAction.action.performed += Pause;
+            pauseAction.action.Enable();
+        }
+
+        Time.timeScale = 1; // Un-Freeze time
     }
-    public void Pause(InputAction.CallbackContext ctx) 
+    public void Pause(InputAction.CallbackContext ctx)
     {
-        pauseCanvas.SetActive(true); // Show menu
-         Cursor.lockState = CursorLockMode.None; // Free the mouse!!
-         Time.timeScale = 0; // Freeze time
+        if (pauseCanvas != null)
+        {
+            pauseCanvas.SetActive(true); // Show menu
+            Cursor.lockState = CursorLockMode.None; // Free the mouse!!
+            Time.timeScale = 0; // Freeze time
+        }
+
     }
 
-    public void UnPause() 
+    public void UnPause()
     {
-          pauseCanvas.SetActive(false); // Get rid of menu
-        Cursor.lockState = CursorLockMode.Locked; // Locks mouse in place
-        Time.timeScale = 1; // Un-Freeze time
+        if (pauseCanvas != null)
+        {
+            pauseCanvas.SetActive(false); // Get rid of menu
+            Cursor.lockState = CursorLockMode.Locked; // Locks mouse in place
+            Time.timeScale = 1; // Un-Freeze time
+        }
+
     }
 
     public void FullScreen(bool inFullScreen) //Toggles fullscreen from button press
-    {   
-        Screen.fullScreen = inFullScreen;   
+    {
+        Screen.fullScreen = inFullScreen;
     }
 
-    public void Resolution(int dropdown) 
+    public void Resolution(int dropdown)
     //toggles screen resoulation, gets the dropdown int from UI Dropdown
     // If we add more resoluations, MAKE THEM IN ORDER FROM LARGE TO SMALL!!! (16:9)
     {
@@ -56,7 +69,7 @@ public class PauseManager : MonoBehaviour
             widith = 1920;
             height = 1080;
         }
-         else if (dropdown == 1)
+        else if (dropdown == 1)
         {
             widith = 1366;
             height = 768;

--- a/Assets/Scripts/Misc/SceneTransitions.cs
+++ b/Assets/Scripts/Misc/SceneTransitions.cs
@@ -1,0 +1,46 @@
+using System.Collections;
+using DG.Tweening;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+public class SceneTransitions : MonoBehaviour
+{
+    public static SceneTransitions Instance;
+    [SerializeField] private Image image;
+    // Assign as child in the inspector :D
+    void Awake()
+    {
+        if (Instance != null)
+        {
+            Destroy(gameObject); // Destroy the duplicate instance
+        }
+        else
+        {
+            Instance = this; // Set this as the instance
+            DontDestroyOnLoad(gameObject); // Keep this instance alive across scenes
+        }
+    }
+
+
+    public void FancyChangeSceneAlt(int sceneNum)
+    // This is what they call a "Wrapper Method"
+    {
+        StartCoroutine(FancyChangeScene(sceneNum));
+    }
+
+
+
+    public IEnumerator FancyChangeScene(int targetScene)
+    // Call this when you want to load a scene, find the number of the target scene in build settings
+    {
+
+        yield return image.DOFade(1, 1.5f).WaitForCompletion();
+
+        SceneManager.LoadScene(targetScene);
+
+        yield return image.DOFade(0, 4.5f).WaitForCompletion();
+
+         transform.DOKill();
+    }
+}

--- a/Assets/Scripts/Misc/SceneTransitions.cs.meta
+++ b/Assets/Scripts/Misc/SceneTransitions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c25d4aa611322dd44b300305eaab1d00
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Misc/UIFX.cs
+++ b/Assets/Scripts/Misc/UIFX.cs
@@ -9,22 +9,33 @@ public class UIFX : MonoBehaviour
     public Vector3 oldScale = new Vector3(1, 1, 1);
 
     // Change these in INSPECTOR if needed
-    
+
     public void MakeBigger()
     {
-        float rotationNum = Random.Range(-3f, 3f);
-        transform.DORotate(new Vector3 (0f, 0f, rotationNum), .5f).SetUpdate(true);
-        transform.DOScale(targetScale, .5f).SetUpdate(true);
+        if (transform != null)
+        {
+            transform.DOKill();
+            float rotationNum = Random.Range(-3f, 3f);
+            transform.DORotate(new Vector3(0f, 0f, rotationNum), .5f).SetUpdate(true);
+            transform.DOScale(targetScale, .5f).SetUpdate(true);
+        }
     }
     public void MakeSmaller()
     {
-        transform.DORotate(new Vector3 (0f, 0f, 0f), .5f).SetUpdate(true);
-        transform.DOScale(oldScale, .5f).SetUpdate(true);
+        if (transform != null)
+        {
+            transform.DOKill();
+            transform.DORotate(new Vector3(0f, 0f, 0f), .5f).SetUpdate(true);
+            transform.DOScale(oldScale, .5f).SetUpdate(true);
+        }
+
     }
 
     void OnDisable()
     {
+        transform.DOKill();
         transform.localScale = oldScale;
+        transform.localRotation = Quaternion.identity;
     }
 
 }

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -4,5 +4,11 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Scenes/Main Menu.unity
+    guid: 57faff1d3ccdf8848913a3df32ab7f11
+  - enabled: 1
+    path: Assets/Scenes/The Testing Scene.unity
+    guid: 097ad69df356e6c458e2e6cc7b941098
   m_configObjects: {}


### PR DESCRIPTION
Added a Canvas that stays even through scene changes (using don't destroy on load); call the FancySceneChange method with an int which correlates to the scene number to load, for example load the main menu by doing SceneTransitions.StartCoroutine(FancySceneTransition(0));

So when player dies, you can call the fancy scene transition to fade in and out from black (which it does automatically because it does not destroy on load) which would also reload the scene you input :D

Made the main menu Scene 0 and "The Testing Scene" 1 for now